### PR TITLE
chore: bump version to v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-the-gathering-deckforge",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "main": "dist-electron/index.js",
   "author": {


### PR DESCRIPTION
Automated version bump to match the [`v0.2.0`](https://github.com/AleBL/magic-the-gathering-deckforge/releases/tag/v0.2.0) release.